### PR TITLE
Ensure DB client connects before Drizzle usage

### DIFF
--- a/src/drizzle/index.ts
+++ b/src/drizzle/index.ts
@@ -6,10 +6,9 @@ import * as schema from "./schema";
 // const sql = neon(process.env.DATABASE_URL!); // for neon db
 const sql = new Client({ connectionString: process.env.DATABASE_URL! });
 
-const main = async () => {
-  await sql.connect();
-};
-
-main();
+// Ensure the PostgreSQL client establishes a connection before it is used.
+// Without awaiting the connection, queries may be issued before the client is
+// ready which can lead to runtime errors.
+await sql.connect();
 
 export const db = drizzle(sql, { schema });


### PR DESCRIPTION
## Summary
- ensure Postgres client connects before initializing Drizzle ORM to prevent race conditions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6896200bf684832ca804e5815e5e727b